### PR TITLE
Se soluciona un problema con el app.iml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 #.idea/**/*
 #local.properties
 app/.gitignore
-app/app.iml
+
 
 # Files: Including important
 !.gitignore
@@ -16,3 +16,4 @@ app/app.iml
 # !app/
 !app/**/main/
 !app/**/main/**/*
+app/app.iml


### PR DESCRIPTION
Antes con las ultimas dos lineas !app/**/main/ !app/**/main/**/* se ignoraba el comando app/app.iml, entonces de debe de pasar hasta abajo para que le haga caso y no lo suba, porque ese archivo se cambia cada de se abre en android studio.